### PR TITLE
feat: support custom account and issuer for uri

### DIFF
--- a/dotp_test.go
+++ b/dotp_test.go
@@ -18,3 +18,11 @@ func TestMain(t *testing.T) {
 		t.Errorf("Error: Failed to validate TOTP")
 	}
 }
+
+func TestGenerateTotpUri(t *testing.T) {
+	uri := GenerateTotpUri("ABCDEF", "foo@bar", "myapp")
+	expected := "otpauth://totp/myapp:foo@bar?issuer=myapp&secret=ABCDEF"
+	if uri != expected {
+		t.Errorf("Unexpected URI: %s", uri)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -108,7 +108,13 @@ func main() {
 
 	case "uri":
 		secret := LoadSecret(config)
-		totpUri := GenerateTotpUri(secret, "demo-account", "demo-app")
+		account := config.AccountName
+		issuer := config.Issuer
+		if account == "" || issuer == "" {
+			fmt.Fprintf(os.Stderr, "--account and --issuer are required for uri action\n")
+			os.Exit(1)
+		}
+		totpUri := GenerateTotpUri(secret, account, issuer)
 		fmt.Print(totpUri)
 		os.Exit(0)
 


### PR DESCRIPTION
## Summary
- use `--account` and `--issuer` flags when generating otpauth URI
- enforce that account and issuer are provided
- test URI generation